### PR TITLE
fix(front): `NavBar` link clicking

### DIFF
--- a/app/front/app/components/NavBar.tsx
+++ b/app/front/app/components/NavBar.tsx
@@ -41,18 +41,17 @@ function MainNav() {
     return (
         <div className='mr-4 hidden gap-2 md:flex'>
             {navItems.map((item, index) => (
-                <Button key={index} variant='link'>
-                    <NavLink
-                        to={item.href}
-                        className={({ isActive, isPending }) => {
-                            return classNames({
-                                underline: isActive,
-                            });
-                        }}
-                    >
-                        {item.label}
-                    </NavLink>
-                </Button>
+                <NavLink
+                    key={item.href}
+                    to={item.href}
+                    className={({ isActive, isPending }) => {
+                        return classNames('text-primary underline-offset-4 hover:underline', 'px-2 py-2', {
+                            'text-violet-600 underline font-bold': isActive,
+                        });
+                    }}
+                >
+                    {item.label}
+                </NavLink>
             ))}
         </div>
     );
@@ -82,7 +81,7 @@ function MobileNav() {
                                 to={item.href}
                                 className={({ isActive, isPending }) => {
                                     return classNames('mb-4 flex flex-row items-center', {
-                                        underline: isActive,
+                                        'text-violet-600 font-bold': isActive,
                                     });
                                 }}
                                 onClick={() => {


### PR DESCRIPTION
Currently when hovering near a `NavBar` Link it underlines, but when you don't exactly click on the text it does not open the page, which is bad UX.
Therefore just threw the Button out and used manual styling, which now fixes this issue.

Additionally the current selected page is now shown bold and violet.