### PR TITLE
refactor(front): rephrase wording together with order SC members

### DIFF
--- a/app/front/app/components/NavBar.tsx
+++ b/app/front/app/components/NavBar.tsx
@@ -31,11 +31,6 @@ const navItems = [
         icon: Home,
     },
     {
-        label: 'About',
-        href: '/about',
-        icon: Info,
-    },
-    {
         label: 'Issues',
         href: '/issues',
         icon: TriangleAlert,
@@ -44,6 +39,11 @@ const navItems = [
         label: 'Contact',
         href: '/contact',
         icon: MessageCircle,
+    },
+    {
+        label: 'About',
+        href: '/about',
+        icon: Info,
     },
 ];
 

--- a/app/front/app/routes/_index.tsx
+++ b/app/front/app/routes/_index.tsx
@@ -26,11 +26,11 @@ export default function Index() {
     const data = useLoaderData<LoaderData>();
 
     return (
-        <div>
+        <div className="flex flex-col min-h-screen">
             <NavBar login={data.session.login} role={data.session.role} />
 
-            <div className='flex flex-col items-center mt-32'>
-                <div className='flex flex-col items-center mb-4 text-7xl md:text-8xl font-bold'>
+            <div className='flex flex-col items-center justify-center flex-1'>
+                <div className='flex flex-col items-center mb-4 text-7xl md:text-8xl font-bold text-center'>
                     <p>STUDENT</p>
                     <p>COUNCIL</p>
                 </div>

--- a/app/front/app/routes/_index.tsx
+++ b/app/front/app/routes/_index.tsx
@@ -26,7 +26,7 @@ export default function Index() {
     const data = useLoaderData<LoaderData>();
 
     return (
-        <div className="flex flex-col min-h-screen">
+        <div className='flex flex-col min-h-screen'>
             <NavBar login={data.session.login} role={data.session.role} />
 
             <div className='flex flex-col items-center justify-center flex-1'>

--- a/app/front/app/routes/_index.tsx
+++ b/app/front/app/routes/_index.tsx
@@ -29,7 +29,7 @@ export default function Index() {
         <div>
             <NavBar login={data.session.login} role={data.session.role} />
 
-            <div className='flex flex-col items-center mt-80 mb-80'>
+            <div className='flex flex-col items-center mt-32'>
                 <div className='flex flex-col items-center mb-4 text-7xl md:text-8xl font-bold'>
                     <p>STUDENT</p>
                     <p>COUNCIL</p>
@@ -40,39 +40,6 @@ export default function Index() {
                 <Link to='/issues/new'>
                     <Button>Have a problem?</Button>
                 </Link>
-            </div>
-            <div className='flex flex-col md:flex-row md:items-center'>
-                <img
-                    src='/img/landing-page.png'
-                    alt='Landing Page'
-                    className='mx-4 mb-4 rounded md:size-6/12 shadow-md md:shadow-2xl'
-                />
-                <div className='mx-4'>
-                    <div className='mb-4'>
-                        <H2 className='mb-2'>What is the Student Council?</H2>
-                        <p>
-                            We are students who have been elected by you and your peers. We represent the student body
-                            in the school's decision making process. This platform allows you to anonymously share
-                            thoughts, ideas, and concerns with the community. While your submissions remain anonymous to
-                            the public, the student council members will know who submitted what, to ensure accurate and
-                            effective representation.
-                        </p>
-                    </div>
-                    <div>
-                        <H3>Why?</H3>
-                        <ul className='ml-4'>
-                            <li>
-                                Because we want <span className='font-bold'>everyone to be heard</span>.
-                            </li>
-                            <li>
-                                Because we want <span className='font-bold'>transparent communication</span>.
-                            </li>
-                            <li>
-                                Because we want <span className='font-bold'>to make a difference</span>.
-                            </li>
-                        </ul>
-                    </div>
-                </div>
             </div>
         </div>
     );

--- a/app/front/app/routes/about.tsx
+++ b/app/front/app/routes/about.tsx
@@ -2,6 +2,7 @@ import { LoaderFunctionArgs, MetaFunction, Session } from '@remix-run/node';
 import { Link, useLoaderData } from '@remix-run/react';
 import NavBar from '~/components/NavBar';
 import { H1 } from '~/components/ui/H1';
+import { H2 } from '~/components/ui/H2';
 import { H3 } from '~/components/ui/H3';
 import { Avatar, AvatarFallback, AvatarImage } from '~/components/ui/avatar';
 import { Button } from '~/components/ui/button';
@@ -53,9 +54,23 @@ export default function About() {
     return (
         <div>
             <NavBar login={data.session.login} role={data.session.role} />
-            <div className='mb-8 md:mb-16 md:mt-16 flex flex-col items-center'>
-                <H1 className='mt-4 mb-2 text-center'>Student Council</H1>
-                <p className='mx-4 text-lg'>(In random order.)</p>
+            <div className='mb-8 mb-8 md:mt-16 flex flex-col items-center'>
+                <div className='flex flex-col md:flex-row md:items-center justify-center'>
+                    <div className='mx-4'>
+                        <div className='mb-4'>
+                            <H1 className='mb-8 text-center'>What is the Student Council?</H1>
+                            <p className='text-xl text-center'>
+                                We are students who have been elected by you and your peers.
+                                <br />
+                                We represent the student body
+                                in the school's decision making process.
+                                <br />
+                                This platform allows you to anonymously share
+                                thoughts, ideas, and concerns with the community.
+                            </p>
+                        </div>
+                    </div>
+                </div>
             </div>
             <div className='flex flex-col md:flex-row md:flex-wrap md:justify-center md:mx-24'>
                 {data.councilMembers.map((member) => (
@@ -83,7 +98,7 @@ export default function About() {
                                         {member.login}
                                     </Link>
                                 </Button>
-                            </p> 
+                            </p>
                         </div> */}
                     </div>
                 ))}

--- a/app/front/app/routes/about.tsx
+++ b/app/front/app/routes/about.tsx
@@ -62,11 +62,10 @@ export default function About() {
                             <p className='text-xl text-center'>
                                 We are students who have been elected by you and your peers.
                                 <br />
-                                We represent the student body
-                                in the school's decision making process.
+                                We represent the student body in the school's decision making process.
                                 <br />
-                                This platform allows you to anonymously share
-                                thoughts, ideas, and concerns with the community.
+                                This platform allows you to anonymously share thoughts, ideas, and concerns with the
+                                community.
                             </p>
                         </div>
                     </div>

--- a/app/front/app/routes/about.tsx
+++ b/app/front/app/routes/about.tsx
@@ -54,7 +54,7 @@ export default function About() {
     return (
         <div>
             <NavBar login={data.session.login} role={data.session.role} />
-            <div className='mb-8 mb-8 md:mt-16 flex flex-col items-center'>
+            <div className='mb-8 mt-8 md:mt-16 flex flex-col items-center'>
                 <div className='flex flex-col md:flex-row md:items-center justify-center'>
                     <div className='mx-4'>
                         <div className='mb-4'>

--- a/app/front/app/routes/contact.tsx
+++ b/app/front/app/routes/contact.tsx
@@ -123,18 +123,17 @@ export default function Contact() {
             <Separator />
             <div className='md:flex md:justify-center'>
                 <p className='mt-4 mx-4 md:w-3/5'>
-                    Do you have an issue you would like to stay private? Contact us directly instead. We will try to
-                    help you as soon as possible.
+                    Do you have an issue or suggestion you would like to stay private? Use this contact form.
                 </p>
             </div>
             <div className='flex justify-center mt-4 mx-8 mb-4'>
                 <contactFetcher.Form className='md:w-3/5' method='post'>
                     <div className='mt-4'>
                         <Label htmlFor='message' className='text-lg'>
-                            What do you want to tell us?
+                            What would you like to tell us?
                         </Label>
                         <Textarea
-                            placeholder='Please describe your issue here. Markdown is supported.'
+                            placeholder='Please describe your issue or suggestion here... (Markdown is supported.)'
                             name='message'
                             className={classNames('h-48', {
                                 'border-red-600': !!contactFetcher.data?.errors?.message,
@@ -188,10 +187,8 @@ export default function Contact() {
                     )}
 
                     <Warning title='Important' className='mt-4 w-auto'>
-                        We will store your data so we can contact you. If you want to raise concerns anonymously, please
-                        open an issue.
-                        <br />
                         Contacting is <span className='font-bold uppercase'>not anonymous</span>.
+                        We will store your data so we can get back to you.
                     </Warning>
 
                     <Button

--- a/app/front/app/routes/contact.tsx
+++ b/app/front/app/routes/contact.tsx
@@ -170,7 +170,7 @@ export default function Contact() {
                             </div>
                             <div className='flex items-center space-x-2'>
                                 <RadioGroupItem value='nothing' id='nothing' />
-                                <Label htmlFor='nothing'>No need to reach out to me</Label>
+                                <Label htmlFor='nothing'>No follow-up needed</Label>
                             </div>
 
                         </RadioGroup>

--- a/app/front/app/routes/contact.tsx
+++ b/app/front/app/routes/contact.tsx
@@ -119,7 +119,7 @@ export default function Contact() {
         <div>
             <NavBar login={data.login} role={data.role} />
             <div className='md:flex md:justify-center'>
-                <H1 className='m-4 md:w-3/5'>Contact The Student Council</H1>
+                <H1 className='m-4 md:w-3/5'>Contact the Student Council</H1>
             </div>
             <Separator />
             <div className='md:flex md:justify-center'>

--- a/app/front/app/routes/contact.tsx
+++ b/app/front/app/routes/contact.tsx
@@ -172,7 +172,6 @@ export default function Contact() {
                                 <RadioGroupItem value='nothing' id='nothing' />
                                 <Label htmlFor='nothing'>No follow-up needed</Label>
                             </div>
-
                         </RadioGroup>
 
                         {contactOption === 'email' && (
@@ -196,14 +195,11 @@ export default function Contact() {
                                 </FormErrorMessage>
                             </div>
                         )}
-
                     </div>
 
-
-
                     <Warning title='Important' className='mt-4 w-auto'>
-                        Contacting is <span className='font-bold uppercase'>not anonymous</span>.
-                        We will store your data so we can get back to you.
+                        Contacting is <span className='font-bold uppercase'>not anonymous</span>. We will store your
+                        data so we can get back to you.
                     </Warning>
 
                     <Button
@@ -217,7 +213,9 @@ export default function Contact() {
                     <FormErrorMessage className='mt-2'>{contactFetcher.data?.errors?.discordError}</FormErrorMessage>
                     {contactFetcher.data?.success && (
                         <p className='text-green-600 text-xs mt-1'>
-                            {contactFetcher.data?.contactWay !== 'nothing' ? "We have received your message, we will get back to you soon!" : "We have received your message." }
+                            {contactFetcher.data?.contactWay !== 'nothing'
+                                ? 'We have received your message, we will get back to you soon!'
+                                : 'We have received your message.'}
                         </p>
                     )}
                 </contactFetcher.Form>

--- a/app/front/app/routes/issues.new.tsx
+++ b/app/front/app/routes/issues.new.tsx
@@ -120,7 +120,8 @@ export default function IssuesNew() {
             <Separator />
             <div className='md:flex md:justify-center'>
                 <p className='mt-4 mx-4 md:w-3/5'>
-                    Open an anonymous issue to discuss what's important to you with the community. <br />
+                    Open an anonymous issue to discuss what's important to you with the community.
+                    <br />
                     If you would like to share your issue with the student council members only, please go to the <Link to='/contact' className='underline'>contact form</Link>.
                 </p>
             </div>
@@ -169,7 +170,8 @@ export default function IssuesNew() {
                         <span className='font-bold'>Note:</span> Currently you are not able to edit issues after
                         submitting them.
                         <div className='mb-2' />
-                        Issues are anonymous to the public, this means students won't know who submitted which issue. <br />
+                        Issues are anonymous to the public, this means students won't know who submitted which issue.
+                        <br />
                         However, the student council members can check the author to prevent spam.
                     </Info>
 

--- a/app/front/app/routes/issues.new.tsx
+++ b/app/front/app/routes/issues.new.tsx
@@ -122,7 +122,11 @@ export default function IssuesNew() {
                 <p className='mt-4 mx-4 md:w-3/5'>
                     Open an anonymous issue to discuss what's important to you with the community.
                     <br />
-                    If you would like to share your issue with the student council members only, please go to the <Link to='/contact' className='underline'>contact form</Link>.
+                    If you would like to share your issue with the student council members only, please go to the{' '}
+                    <Link to='/contact' className='underline'>
+                        contact form
+                    </Link>
+                    .
                 </p>
             </div>
             <div className='flex justify-center mt-4 mx-8'>

--- a/app/front/app/routes/issues.new.tsx
+++ b/app/front/app/routes/issues.new.tsx
@@ -115,7 +115,7 @@ export default function IssuesNew() {
         <div>
             <NavBar />
             <div className='md:flex md:justify-center'>
-                <H1 className='m-4 md:w-3/5'>Create A Public Issue</H1>
+                <H1 className='m-4 md:w-3/5'>Create a Public Issue</H1>
             </div>
             <Separator />
             <div className='md:flex md:justify-center'>

--- a/app/front/app/routes/issues.new.tsx
+++ b/app/front/app/routes/issues.new.tsx
@@ -1,5 +1,5 @@
 import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
-import { json, useFetcher, useNavigate } from '@remix-run/react';
+import { json, useFetcher, useNavigate, Link } from '@remix-run/react';
 import classNames from 'classnames';
 import { useEffect, useState } from 'react';
 import { z } from 'zod';
@@ -115,14 +115,13 @@ export default function IssuesNew() {
         <div>
             <NavBar />
             <div className='md:flex md:justify-center'>
-                <H1 className='m-4 md:w-3/5'>Create A New Issue</H1>
+                <H1 className='m-4 md:w-3/5'>Create A Public Issue</H1>
             </div>
             <Separator />
             <div className='md:flex md:justify-center'>
                 <p className='mt-4 mx-4 md:w-3/5'>
-                    Issues are <span className='font-bold'>the</span> way to discuss with the community. While issues
-                    and their comments remain anonym to the public, the student council members will know who submitted
-                    what, to ensure accurate and effective representation.
+                    Open an anonymous issue to discuss what's important to you with the community. <br />
+                    If you would like to share your issue with the student council members only, please go to the <Link to='/contact' className='underline'>contact form</Link>.
                 </p>
             </div>
             <div className='flex justify-center mt-4 mx-8'>
@@ -148,7 +147,8 @@ export default function IssuesNew() {
                             Issue Description
                         </Label>
                         <Textarea
-                            placeholder="Start explaining your issue here... (Currently we don't support markdown, but we will in the future.)"
+                            placeholder="Please describe your issue or suggestion here...
+(Currently we don't support markdown for public issues, but we will in the future.)"
                             name='description'
                             className={classNames('h-48', {
                                 'border-red-600': !!createIssueFetcher.data?.errors?.description,
@@ -167,11 +167,10 @@ export default function IssuesNew() {
 
                     <Info className='mt-4 w-auto'>
                         <span className='font-bold'>Note:</span> Currently you are not able to edit issues after
-                        submittng them.
+                        submitting them.
                         <div className='mb-2' />
-                        Issues are anonymous to the public, this means students won't know who submitted which issue.
-                        But in order to ensure accurate and effective representation the council members know who
-                        submitted which issue.
+                        Issues are anonymous to the public, this means students won't know who submitted which issue. <br />
+                        However, the student council members can check the author to prevent spam.
                     </Info>
 
                     <Button type='submit' disabled={!!createIssueFetcher.formData} className='mt-4'>


### PR DESCRIPTION
Ildi, Kamilla, Simon and me went over the whole website together to check all wording.

We also made the following changes to the frontend:
- Move the description of the student council from the landing page to the about page.
- Add a no follow-up option to the contact form.
- Make the options in the contact from clickable.
- Center the landing page.