### PR TITLE
feat: remove `DATABASE_URL` requirement for .env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
             DISCORD_WEBHOOK_ID: ${DISCORD_WEBHOOK_ID}
             DISCORD_WEBHOOK_TOKEN: ${DISCORD_WEBHOOK_TOKEN}
             SUPER_ADMIN: ${SUPER_ADMIN}
-            DATABASE_URL: ${DATABASE_URL}
+            DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_NAME}
         profiles:
             - prod
 
@@ -70,7 +70,7 @@ services:
             DISCORD_WEBHOOK_ID: ${DISCORD_WEBHOOK_ID}
             DISCORD_WEBHOOK_TOKEN: ${DISCORD_WEBHOOK_TOKEN}
             SUPER_ADMIN: ${SUPER_ADMIN}
-            DATABASE_URL: ${DATABASE_URL}
+            DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_NAME}
         volumes:
             - ./src:/app
             - /app/node_modules


### PR DESCRIPTION
The `DATABASE_URL` can be constructed from the existing other variables. Therefore I changed the `docker-compose.yml` to do just that.