### PR TITLE
feat(front): forward to intra profile when clicking on council member avatar

### DIFF
--- a/src/app/routes/about.tsx
+++ b/src/app/routes/about.tsx
@@ -64,10 +64,12 @@ export default function About() {
             <div className='flex flex-col md:flex-row md:flex-wrap md:justify-center md:mx-24'>
                 {data.councilMembers.map((member) => (
                     <div key={member.email} className='md:w-1/4 md:mx-20 flex flex-col items-center mb-8'>
-                        <Avatar className='rounded-xl size-60'>
-                            <AvatarImage src={member.profilePictureUrl} className='object-cover' />
-                            <AvatarFallback>{member.firstName.slice(0, 2)}</AvatarFallback>
-                        </Avatar>
+                        <Link to={`https://profile.intra.42.fr/users/${member.login}`} target='_blank'>
+                            <Avatar className='rounded-xl size-60'>
+                                <AvatarImage src={member.profilePictureUrl} className='object-cover' />
+                                <AvatarFallback>{member.firstName.slice(0, 2)}</AvatarFallback>
+                            </Avatar>
+                        </Link>
 
                         <H3 className='mt-4'>
                             {member.firstName} {member.lastName}


### PR DESCRIPTION
Just when clicking on the picture, not the name. This way it's still easy to copy the name of the council member (if anyone ever needs to do that).