### PR TITLE
improve(front): improve description layout

### DIFF
--- a/src/app/routes/contact.tsx
+++ b/src/app/routes/contact.tsx
@@ -127,7 +127,7 @@ export default function Contact() {
             </div>
             <Separator />
             <div className='md:flex md:justify-center mx-4 md:mx-0'>
-                <p className='mt-4 md:w-3/5'>
+                <p className='mt-4 md:w-3/5 text-xl'>
                     Do you have an issue or suggestion you would like to stay private? Use this contact form.
                 </p>
             </div>

--- a/src/app/routes/contact.tsx
+++ b/src/app/routes/contact.tsx
@@ -133,7 +133,7 @@ export default function Contact() {
             </div>
             <div className='flex justify-center mt-4 mb-4 mx-4 md:mx-0'>
                 <contactFetcher.Form className='md:w-3/5' method='post'>
-                    <div className='mt-4'>
+                    <div className='mt-2'>
                         <Label htmlFor='message' className='text-lg'>
                             What would you like to tell us?
                         </Label>

--- a/src/app/routes/issues.new.tsx
+++ b/src/app/routes/issues.new.tsx
@@ -131,10 +131,10 @@ export default function IssuesNew() {
             </div>
             <Separator />
             <div className='md:flex md:justify-center mx-4 md:mx-0'>
-                <p className='mt-4 md:w-3/5'>
+                <p className='mt-4 md:w-3/5 text-xl'>
                     Open an anonymous issue to discuss what's important to you with the community.
                     <br />
-                    If you would like to share your issue with the student council members only, please go to the{' '}
+                    If you would like to share your issue with the student council only, please go to the{' '}
                     <Link to='/contact' className='underline'>
                         contact form
                     </Link>

--- a/src/app/routes/issues.new.tsx
+++ b/src/app/routes/issues.new.tsx
@@ -131,7 +131,7 @@ export default function IssuesNew() {
             </div>
             <Separator />
             <div className='md:flex md:justify-center mx-4 md:mx-0'>
-                <p className='mt-4 md:w-3/5 text-xl'>
+                <p className='mt-4 mb-2 md:w-3/5 text-xl'>
                     Open an anonymous issue to discuss what's important to you with the community.
                     <br />
                     If you would like to share your issue with the student council only, please go to the{' '}


### PR DESCRIPTION
- Increase text size of descriptions in new issue and contact page to make them equal with the landing and about page.
- Make spacing after descriptions equal.

![image](https://github.com/user-attachments/assets/f3885baa-f2e1-4bfa-85a7-67332a91e239)
![image](https://github.com/user-attachments/assets/27f00fcc-6e95-4553-b53a-e86dd126a73e)

![image](https://github.com/user-attachments/assets/ebc94c2e-cec2-418a-a638-6f1fe9a0b85f)
![image](https://github.com/user-attachments/assets/067dbb87-54a4-4cd6-80c5-09d1523cef95)