### PR TITLE
improve: remember archived tab state when navigating back to issues list

### DIFF
--- a/src/app/root.tsx
+++ b/src/app/root.tsx
@@ -9,6 +9,7 @@ import {
     isRouteErrorResponse,
     useRouteError,
 } from '@remix-run/react';
+import { useEffect } from 'react';
 import stylesheet from '~/tailwind.css?url';
 import { Footer } from './components/Footer';
 import NavBar from './components/NavBar';
@@ -29,6 +30,18 @@ export const links: LinksFunction = () => {
 };
 
 export function Layout({ children }: { children: React.ReactNode }) {
+    useEffect(() => {
+        const handleUnload = () => {
+            localStorage.removeItem('currentTab');
+        };
+
+        window.addEventListener('beforeunload', handleUnload);
+
+        return () => {
+            window.removeEventListener('beforeunload', handleUnload);
+        };
+    }, []);
+
     return (
         <html lang='en'>
             <head>
@@ -39,7 +52,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
             </head>
             <body>
                 <div className='min-h-screen'>{children}</div>
-
                 <Footer />
                 <ScrollRestoration />
                 <Scripts />

--- a/src/app/routes/issues.$id.tsx
+++ b/src/app/routes/issues.$id.tsx
@@ -3,7 +3,7 @@ import NavBar from '~/components/NavBar';
 import { requireAdminSession, requireSessionData, SessionData } from '~/utils/session.server';
 import { useState, useEffect, useRef } from 'react';
 import { json } from '@remix-run/node';
-import { useLoaderData, Link, useFetcher, Form } from '@remix-run/react';
+import { useLoaderData, Link, useFetcher, Form, useLocation } from '@remix-run/react';
 import { Button } from '~/components/ui/button';
 import { db } from '~/utils/db.server';
 import { RateLimiterMemory } from 'rate-limiter-flexible';
@@ -244,6 +244,8 @@ export default function IssueDetail() {
     const [isFormValid, setIsFormValid] = useState(false);
 
     const commentRef = useRef(null);
+    const location = useLocation();
+    const archived = new URLSearchParams(location.search).has('archived');
 
     useEffect(() => {
         if (fetcher.state === 'idle' && fetcher.data && !fetcher.data?.errors?.message) {
@@ -292,7 +294,7 @@ export default function IssueDetail() {
                 <div className='md:w-4/5 p-4'>
                     <div className='flex flex-row justify-between'>
                         <H1>Issue #{issue.id}</H1>
-                        <Link to='/issues' className=''>
+                        <Link to={`/issues${archived ? '?archived' : ''}`} className=''>
                             <Button>
                                 <ChevronLeft />
                                 Go Back

--- a/src/app/routes/issues.$id.tsx
+++ b/src/app/routes/issues.$id.tsx
@@ -313,10 +313,8 @@ export default function IssueDetail() {
                                         <Button type='submit' className=' bg-rose-500 hover:bg-rose-600'>
                                             {issue.archived ? 'Unarchive' : 'Archive'}
                                         </Button>
-                                        <p className='text-center text-rose-800 font-bold ml-4'>
-                                            {issue.archived
-                                                ? 'Only admins can see this issue.'
-                                                : 'This issue is visible to students.'}
+                                        <p className='text-center text-rose-800 ml-4'>
+                                            Archived issues are visible to students, but cannot be interacted with anymore.
                                         </p>
                                     </div>
                                 </Form>

--- a/src/app/routes/issues.$id.tsx
+++ b/src/app/routes/issues.$id.tsx
@@ -316,7 +316,8 @@ export default function IssueDetail() {
                                             {issue.archived ? 'Unarchive' : 'Archive'}
                                         </Button>
                                         <p className='text-center text-rose-800 ml-4'>
-                                            Archived issues are visible to students, but cannot be interacted with anymore.
+                                            Archived issues are visible to students, but cannot be interacted with
+                                            anymore.
                                         </p>
                                     </div>
                                 </Form>

--- a/src/app/routes/issues._index.tsx
+++ b/src/app/routes/issues._index.tsx
@@ -1,5 +1,5 @@
 import { LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
-import { useLoaderData, Link, useNavigate, useSearchParams } from '@remix-run/react';
+import { useLoaderData, Link, useNavigate, useLocation } from '@remix-run/react';
 import { requireSessionData, SessionData } from '~/utils/session.server';
 import {
     ArrowUpAZ,
@@ -16,12 +16,10 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import NavBar from '~/components/NavBar';
 import { Warning } from '~/components/alert/Warning';
-import { useState, HTMLAttributes } from 'react';
+import { useState, useEffect } from 'react';
 import { db } from '~/utils/db.server';
 import { UserRole } from '@prisma/client';
-import classNames from 'classnames';
 import {
-    ColumnDef,
     flexRender,
     getCoreRowModel,
     getSortedRowModel,
@@ -79,6 +77,16 @@ export default function Issues() {
     const { issues, session, archived } = useLoaderData<LoaderData>();
     const [currentTab, setCurrentTab] = useState(archived ? 'archived' : 'online');
     const navigate = useNavigate();
+    const location = useLocation();
+
+    useEffect(() => {
+        const params = new URLSearchParams(location.search);
+        if (params.has('archived')) {
+            setCurrentTab('archived');
+        } else {
+            setCurrentTab('online');
+        }
+    }, [location]);
 
     const handleTabChange = (newTab: string) => {
         setCurrentTab(newTab);

--- a/src/app/routes/issues._index.tsx
+++ b/src/app/routes/issues._index.tsx
@@ -156,8 +156,8 @@ export default function Issues() {
     );
 }
 
-function IssuesTable({ issues, currentTab }) {
-    const columns = [
+function IssuesTable({ issues, currentTab }: HTMLAttributes<HTMLTableElement> & { issues: SerializeFrom<Issue[]>, currentTab: string }) {
+    const columns: ColumnDef<SerializeFrom<Issue>>[] = [
         {
             accessorKey: 'title',
             sortingFn: (rowA, rowB) => {

--- a/src/app/routes/issues._index.tsx
+++ b/src/app/routes/issues._index.tsx
@@ -19,13 +19,7 @@ import { Warning } from '~/components/alert/Warning';
 import { useState, useEffect } from 'react';
 import { db } from '~/utils/db.server';
 import { UserRole } from '@prisma/client';
-import {
-    flexRender,
-    getCoreRowModel,
-    getSortedRowModel,
-    SortingState,
-    useReactTable,
-} from '@tanstack/react-table';
+import { flexRender, getCoreRowModel, getSortedRowModel, SortingState, useReactTable } from '@tanstack/react-table';
 import { ScrollArea, ScrollBar } from '~/components/ui/scroll-area';
 
 export const meta: MetaFunction = () => {
@@ -123,7 +117,10 @@ export default function Issues() {
                                 <CardDescription>This is what students are currently talking about.</CardDescription>
                             </CardHeader>
                             <CardContent>
-                                <IssuesTable issues={issues.filter((issue) => !issue.archived)} currentTab={currentTab} />
+                                <IssuesTable
+                                    issues={issues.filter((issue) => !issue.archived)}
+                                    currentTab={currentTab}
+                                />
                             </CardContent>
                             <CardFooter>
                                 <div className='text-xs text-muted-foreground'>
@@ -140,7 +137,10 @@ export default function Issues() {
                                 <CardDescription>This is what students are currently talking about.</CardDescription>
                             </CardHeader>
                             <CardContent>
-                                <IssuesTable issues={issues.filter((issue) => issue.archived)} currentTab={currentTab} />
+                                <IssuesTable
+                                    issues={issues.filter((issue) => issue.archived)}
+                                    currentTab={currentTab}
+                                />
                             </CardContent>
                             <CardFooter>
                                 <div className='text-xs text-muted-foreground'>
@@ -267,7 +267,11 @@ function IssuesTable({ issues, currentTab }) {
                                     <TableRow
                                         key={row.id}
                                         data-state={row.getIsSelected() && 'selected'}
-                                        onClick={() => navigate(`/issues/${row.original.id}${currentTab === 'archived' ? '?archived' : ''}`)}
+                                        onClick={() =>
+                                            navigate(
+                                                `/issues/${row.original.id}${currentTab === 'archived' ? '?archived' : ''}`,
+                                            )
+                                        }
                                         className='hover:cursor-pointer hover:bg-slate-100'
                                     >
                                         {row.getVisibleCells().map((cell) => (

--- a/src/app/routes/issues._index.tsx
+++ b/src/app/routes/issues._index.tsx
@@ -156,7 +156,10 @@ export default function Issues() {
     );
 }
 
-function IssuesTable({ issues, currentTab }: HTMLAttributes<HTMLTableElement> & { issues: SerializeFrom<Issue[]>, currentTab: string }) {
+function IssuesTable({
+    issues,
+    currentTab,
+}: HTMLAttributes<HTMLTableElement> & { issues: SerializeFrom<Issue[]>; currentTab: string }) {
     const columns: ColumnDef<SerializeFrom<Issue>>[] = [
         {
             accessorKey: 'title',


### PR DESCRIPTION
## TODO
- [ ] Clicking on issues when already in the archived tab on the issues page should go back to the online tab.
- [ ] After having created a new issue, the tab state should be set to the online tab.
- [ ] When being on the archived tab, it should add a parameter to the URL so that the state is sharable.