### PR TITLE
FIX: display currently visible issues' count instead of total

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
     db:
         image: postgres

--- a/src/app/routes/issues._index.tsx
+++ b/src/app/routes/issues._index.tsx
@@ -71,8 +71,8 @@ type LoaderData = { issues: Issue[]; session: SessionData };
 
 export default function Issues() {
     const { issues, session } = useLoaderData<LoaderData>();
-    const archivedIssues = issues.filter((issue) => issue.archived)
-    const visibleIssues = issues.filter((issue) => !issue.archived)
+    const archivedIssues = issues.filter((issue) => issue.archived);
+    const visibleIssues = issues.filter((issue) => !issue.archived);
 
     return (
         <div>

--- a/src/app/routes/issues._index.tsx
+++ b/src/app/routes/issues._index.tsx
@@ -71,6 +71,8 @@ type LoaderData = { issues: Issue[]; session: SessionData };
 
 export default function Issues() {
     const { issues, session } = useLoaderData<LoaderData>();
+    const archivedIssues = issues.filter((issue) => issue.archived)
+    const visibleIssues = issues.filter((issue) => !issue.archived)
 
     return (
         <div>
@@ -98,11 +100,11 @@ export default function Issues() {
                                 <CardDescription>This is what students are currently talking about.</CardDescription>
                             </CardHeader>
                             <CardContent>
-                                <IssuesTable issues={issues.filter((issue) => !issue.archived)} />
+                                <IssuesTable issues={visibleIssues} />
                             </CardContent>
                             <CardFooter>
                                 <div className='text-xs text-muted-foreground'>
-                                    Showing <span className='font-bold'>{issues.length}</span>{' '}
+                                    Showing <span className='font-bold'>{visibleIssues.length}</span>{' '}
                                     {issues.length === 1 ? 'issue' : 'issues'}
                                 </div>
                             </CardFooter>
@@ -115,11 +117,11 @@ export default function Issues() {
                                 <CardDescription>This is what students are currently talking about.</CardDescription>
                             </CardHeader>
                             <CardContent>
-                                <IssuesTable issues={issues.filter((issue) => issue.archived)} />
+                                <IssuesTable issues={archivedIssues} />
                             </CardContent>
                             <CardFooter>
                                 <div className='text-xs text-muted-foreground'>
-                                    Showing <span className='font-bold'>{issues.length}</span>{' '}
+                                    Showing <span className='font-bold'>{archivedIssues.length}</span>{' '}
                                     {issues.length === 1 ? 'issue' : 'issues'}
                                 </div>
                             </CardFooter>


### PR DESCRIPTION
Before archiving
![image](https://github.com/user-attachments/assets/fd2e3557-c427-4289-aa03-8c335bbb8d3f)
After archiving
<img width="654" alt="image" src="https://github.com/user-attachments/assets/84d4fac9-e63b-4d9c-bcfb-a89e0e19450d">

Also changed docker-compose.yml to compose.yml and removed the version to follow modern convention