### PR TITLE
refactor: remove unnecessary title separators

### DIFF
--- a/src/app/routes/contact.tsx
+++ b/src/app/routes/contact.tsx
@@ -246,9 +246,8 @@ export default function Contact() {
             <div className='md:flex md:justify-center mx-4 md:mx-0'>
                 <H1 className='my-4 md:w-3/5'>Contact the Student Council</H1>
             </div>
-            <Separator />
             <div className='md:flex md:justify-center mx-4 md:mx-0'>
-                <p className='mt-4 md:w-3/5 text-xl'>
+                <p className='md:w-3/5 text-xl'>
                     Do you have an issue or suggestion you would like to tell us in private? Use this contact form.
                 </p>
             </div>

--- a/src/app/routes/issues.new.tsx
+++ b/src/app/routes/issues.new.tsx
@@ -213,9 +213,8 @@ export default function IssuesNew() {
                     </Link>
                 </div>
             </div>
-            <Separator />
             <div className='md:flex md:justify-center mx-4 md:mx-0'>
-                <p className='mt-4 mb-2 md:w-3/5 text-xl'>
+                <p className='mb-2 md:w-3/5 text-xl'>
                     Open an anonymous issue to discuss what's important to you with the community.
                     <br />
                     If you would like to share your issue with the student council only, please go to the{' '}


### PR DESCRIPTION
As pointed out in #141 separators after a title are unnecessary.