### PR TITLE
improve: change archive policy to 1 week no activity

### DIFF
--- a/src/app/routes/issues._index.tsx
+++ b/src/app/routes/issues._index.tsx
@@ -129,8 +129,8 @@ export default function Issues() {
                     </TabsContent>
                     <TabsContent value='archived' className='flex flex-col justify-center'>
                         <p className='text-muted-foreground pb-2'>
-                            Issues that have been resolved or have been open for 2 weeks and showed no activity for 3
-                            days.
+                            Issues that have been resolved or have been open for 2 weeks and showed no activity for 1
+                            week.
                         </p>
                         <IssuesTable issues={archivedIssues} />
                         <div className='text-xs text-muted-foreground pt-2 pl-2'>


### PR DESCRIPTION
3 days is just too little for people who don't check the website so often or have maybe other responsibilities, unlike us.
1 week is also easier to manage for us, so we can mange it weekly in our meeting.