### PR TITLE
feat: instant feedback for reaching max character limit in input fields

### DIFF
--- a/src/app/routes/contact.tsx
+++ b/src/app/routes/contact.tsx
@@ -10,7 +10,6 @@ import { Button } from '~/components/ui/button';
 import { Input } from '~/components/ui/input';
 import { Label } from '~/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '~/components/ui/radio-group';
-import { Separator } from '~/components/ui/separator';
 import { Textarea } from '~/components/ui/textarea';
 import { sendDiscordWebhook } from '~/utils/discord.server';
 import { SessionData, requireSessionData } from '~/utils/session.server';
@@ -122,6 +121,8 @@ export default function Contact() {
     }>();
 
     const [message, setMessage] = useState('');
+    const [messageLength, setMessageLength] = useState(0);
+    const [showMessageWarning, setShowMessageWarning] = useState(false);
     const [contactOption, setContactOption] = useState<string>('');
     const [anonymousOption, setAnonymousOption] = useState<string>('');
     const [contactEmail, setContactEmail] = useState<string>(`${data.login}@student.42vienna.com`);
@@ -135,17 +136,26 @@ export default function Contact() {
     useEffect(() => {
         if (contactFetcher.data?.success) {
             setMessage('');
+            setMessageLength(0);
+            setShowMessageWarning(false);
             setContactOption('');
             setAnonymousOption('');
             localStorage.removeItem('contact-message');
             localStorage.removeItem('anonymous-option');
             localStorage.removeItem('contact-option');
+
+            if (messageRef.current) {
+                adjustTextareaHeight(messageRef.current);
+            }
         }
     }, [contactFetcher.data?.success]);
 
     useEffect(() => {
         const savedMessage = localStorage.getItem('contact-message');
-        if (savedMessage) setMessage(savedMessage);
+        if (savedMessage) {
+            setMessage(savedMessage);
+            setMessageLength(savedMessage.length);
+        }
 
         const savedAnonymousOption = localStorage.getItem('anonymous-option');
         if (savedAnonymousOption) setAnonymousOption(savedAnonymousOption);
@@ -168,7 +178,34 @@ export default function Contact() {
 
     useEffect(() => {
         localStorage.setItem('contact-message', message);
+
+        if (messageRef.current) {
+            adjustTextareaHeight(messageRef.current);
+        }
     }, [message]);
+
+    const adjustTextareaHeight = (textarea) => {
+        textarea.style.height = 'auto';
+        textarea.style.height = `${Math.max(textarea.scrollHeight, 192)}px`; // Minimum height of 192px (48 * 4)
+    };
+
+    const handleMessageChange = (e) => {
+        const newMessage = e.target.value;
+        setMessage(newMessage);
+        setMessageLength(newMessage.length);
+
+        if (newMessage.length <= MESSAGE_MAX_LENGTH) {
+            setShowMessageWarning(false);
+        }
+    };
+
+    const handleMessageKeyPress = (e) => {
+        const isPrintableKey = e.key.length === 1;
+
+        if (message.length >= MESSAGE_MAX_LENGTH && isPrintableKey) {
+            setShowMessageWarning(true);
+        }
+    };
 
     useEffect(() => {
         if (anonymousOption) {
@@ -254,23 +291,34 @@ export default function Contact() {
             <div className='flex justify-center mt-4 mb-4 mx-4 md:mx-0'>
                 <contactFetcher.Form className='w-full md:w-3/5' method='post' onSubmit={handleSubmit}>
                     <div className='mt-2'>
-                        <Label htmlFor='message' className='text-lg'>
-                            What would you like to tell us?
-                        </Label>
+                        <div className="flex justify-between items-center mb-1">
+                            <Label htmlFor='message' className='text-lg'>
+                                What would you like to tell us?
+                            </Label>
+                            <span className={`text-sm ${messageLength === MESSAGE_MAX_LENGTH ? 'text-red-600' : 'text-gray-500'}`}>
+                                {messageLength}/{MESSAGE_MAX_LENGTH}
+                            </span>
+                        </div>
                         <Textarea
                             placeholder='Please describe your issue or suggestion here... (Markdown is supported.)'
                             name='message'
-                            className={classNames('h-48', {
-                                'border-red-600': !!contactFetcher.data?.errors?.message,
+                            className={classNames('min-h-[192px]', {
+                                'border-red-600': !!contactFetcher.data?.errors?.message || showMessageWarning,
                             })}
                             required
                             autoComplete='off'
                             minLength={MESSAGE_MIN_LENGTH}
                             maxLength={MESSAGE_MAX_LENGTH}
-                            onChange={(e) => setMessage(e.target.value)}
+                            onChange={handleMessageChange}
+                            onKeyDown={handleMessageKeyPress}
                             value={message}
                             ref={messageRef}
                         />
+                        {showMessageWarning && (
+                            <p className="text-red-600 text-sm mt-1">
+                                Maximum message length reached.
+                            </p>
+                        )}
                         <FormErrorMessage className='mt-2'>{contactFetcher.data?.errors?.message}</FormErrorMessage>
                     </div>
 

--- a/src/app/routes/issues.$id.tsx
+++ b/src/app/routes/issues.$id.tsx
@@ -367,6 +367,11 @@ export default function IssueDetail() {
             setCommentText(savedCommentText);
             setCommentLength(savedCommentText.length);
         }
+
+        // Ensure correct initial height
+        if (commentRef.current) {
+            adjustTextareaHeight(commentRef.current);
+        }
     }, [issue.id]);
 
     useEffect(() => {
@@ -411,8 +416,7 @@ export default function IssueDetail() {
             textarea.style.height = '96px'; // Default height (3 rows)
         } else {
             textarea.style.height = 'auto';
-            textarea.style.height = `${textarea.scrollHeight}px`;
-            textarea.style.minHeight = '96px'; // Default height (3 rows)
+            textarea.style.height = `${Math.max(textarea.scrollHeight, 96)}px`;
         }
     };
 
@@ -564,6 +568,7 @@ export default function IssueDetail() {
                                     className={classNames('w-full px-3 py-2 text-sm text-gray-700 border rounded-lg focus:outline-none', {
                                         'border-red-600': showCommentWarning,
                                     })}
+                                    style={{ minHeight: '96px' }}
                                     placeholder='Add a comment...'
                                     value={commentText}
                                     onChange={handleCommentChange}

--- a/src/app/routes/issues.$id.tsx
+++ b/src/app/routes/issues.$id.tsx
@@ -34,7 +34,7 @@ import { Textarea } from '~/components/ui/textarea';
 import { Label } from '~/components/ui/label';
 
 const COMMENT_MIN_LENGTH = 3;
-const COMMENT_MAX_LENGTH = 5000;
+const COMMENT_MAX_LENGTH = 4096;
 
 const createCommentSchema = z.object({
     comment_text: z

--- a/src/app/routes/issues.$id.tsx
+++ b/src/app/routes/issues.$id.tsx
@@ -348,29 +348,10 @@ export default function IssueDetail() {
     const [isFormValid, setIsFormValid] = useState(false);
 
     useEffect(() => {
-        if (fetcher.state === 'idle' && fetcher.data && !fetcher.data?.errors?.message) {
-            // Reset comment text and length after successful submission
-            setCommentText('');
-            setCommentLength(0);
-            setShowCommentWarning(false);
-            localStorage.removeItem(`issue-${issue.id}-comment-text`);
-
-            if (commentRef.current) {
-                adjustTextareaHeight(commentRef.current, true); // Reset height to default
-            }
-        }
-    }, [fetcher.state, fetcher.data, issue.id]);
-
-    useEffect(() => {
         const savedCommentText = localStorage.getItem(`issue-${issue.id}-comment-text`);
         if (savedCommentText) {
             setCommentText(savedCommentText);
             setCommentLength(savedCommentText.length);
-        }
-
-        // Ensure correct initial height
-        if (commentRef.current) {
-            adjustTextareaHeight(commentRef.current);
         }
     }, [issue.id]);
 
@@ -392,6 +373,29 @@ export default function IssueDetail() {
         setIsFormValid(isCommentTextValid);
     }, [commentText]);
 
+    useEffect(() => {
+        if (fetcher.state === 'idle' && fetcher.data && !fetcher.data?.errors?.message) {
+            // Reset comment text and length after successful submission
+            setCommentText('');
+            setCommentLength(0);
+            setShowCommentWarning(false);
+            localStorage.removeItem(`issue-${issue.id}-comment-text`);
+
+            if (commentRef.current) {
+                adjustTextareaHeight(commentRef.current, true); // Reset height to default
+            }
+        }
+    }, [fetcher.state, fetcher.data, issue.id]);
+
+    const adjustTextareaHeight = (textarea, reset = false) => {
+        if (reset) {
+            textarea.style.height = '96px'; // Default height (3 rows)
+        } else {
+            textarea.style.height = 'auto';
+            textarea.style.height = `${Math.max(textarea.scrollHeight, 96)}px`;
+        }
+    };
+
     const handleCommentChange = (e) => {
         const newComment = e.target.value;
         setCommentText(newComment);
@@ -408,15 +412,6 @@ export default function IssueDetail() {
 
         if (commentText.length >= COMMENT_MAX_LENGTH && isPrintableKey) {
             setShowCommentWarning(true);
-        }
-    };
-
-    const adjustTextareaHeight = (textarea, reset = false) => {
-        if (reset) {
-            textarea.style.height = '96px'; // Default height (3 rows)
-        } else {
-            textarea.style.height = 'auto';
-            textarea.style.height = `${Math.max(textarea.scrollHeight, 96)}px`;
         }
     };
 
@@ -573,6 +568,7 @@ export default function IssueDetail() {
                                     value={commentText}
                                     onChange={handleCommentChange}
                                     onKeyDown={handleCommentKeyPress}
+                                    onInput={(e) => adjustTextareaHeight(e.target)}
                                     minLength={COMMENT_MIN_LENGTH}
                                     maxLength={COMMENT_MAX_LENGTH}
                                     ref={commentRef}

--- a/src/app/routes/issues.$id.tsx
+++ b/src/app/routes/issues.$id.tsx
@@ -356,8 +356,11 @@ export default function IssueDetail() {
 
     useEffect(() => {
         const savedCommentText = localStorage.getItem(`issue-${issue.id}-comment-text`);
-        if (savedCommentText) setCommentText(savedCommentText);
-    }, []);
+        if (savedCommentText) {
+            setCommentText(savedCommentText);
+            setCommentLength(savedCommentText.length);
+        }
+    }, [issue.id]);
 
     useEffect(() => {
         if (commentRef.current) {
@@ -367,7 +370,7 @@ export default function IssueDetail() {
 
     useEffect(() => {
         localStorage.setItem(`issue-${issue.id}-comment-text`, commentText);
-    }, [commentText]);
+    }, [commentText, issue.id]);
 
     useEffect(() => {
         let isCommentTextValid = true;
@@ -377,12 +380,6 @@ export default function IssueDetail() {
         setIsFormValid(isCommentTextValid);
     }, [commentText]);
 
-    const handleSubmit = (e) => {
-        if (!isFormValid || fetcher.formData) {
-            e.preventDefault();
-        }
-    };
-
     const handleCommentChange = (e) => {
         const newComment = e.target.value;
         setCommentText(newComment);
@@ -391,6 +388,7 @@ export default function IssueDetail() {
         if (newComment.length <= COMMENT_MAX_LENGTH) {
             setShowCommentWarning(false);
         }
+        adjustTextareaHeight(e.target);
     };
 
     const handleCommentKeyPress = (e) => {
@@ -398,6 +396,18 @@ export default function IssueDetail() {
 
         if (commentText.length >= COMMENT_MAX_LENGTH && isPrintableKey) {
             setShowCommentWarning(true);
+        }
+    };
+
+    const adjustTextareaHeight = (textarea) => {
+        textarea.style.height = 'auto';
+        textarea.style.height = `${textarea.scrollHeight}px`;
+        textarea.style.minHeight = '96px'; // Default height (3 rows)
+    };
+
+    const handleSubmit = (e) => {
+        if (!isFormValid || fetcher.formData) {
+            e.preventDefault();
         }
     };
 
@@ -540,7 +550,6 @@ export default function IssueDetail() {
                                 <Textarea
                                     name='comment_text'
                                     required
-                                    rows={3}
                                     className={classNames('w-full px-3 py-2 text-sm text-gray-700 border rounded-lg focus:outline-none', {
                                         'border-red-600': showCommentWarning,
                                     })}

--- a/src/app/routes/issues.$id.tsx
+++ b/src/app/routes/issues.$id.tsx
@@ -349,10 +349,17 @@ export default function IssueDetail() {
 
     useEffect(() => {
         if (fetcher.state === 'idle' && fetcher.data && !fetcher.data?.errors?.message) {
-            formRef.current?.reset();
+            // Reset comment text and length after successful submission
             setCommentText('');
+            setCommentLength(0);
+            setShowCommentWarning(false);
+            localStorage.removeItem(`issue-${issue.id}-comment-text`);
+
+            if (commentRef.current) {
+                adjustTextareaHeight(commentRef.current, true); // Reset height to default
+            }
         }
-    }, [fetcher.state, fetcher.data]);
+    }, [fetcher.state, fetcher.data, issue.id]);
 
     useEffect(() => {
         const savedCommentText = localStorage.getItem(`issue-${issue.id}-comment-text`);
@@ -399,10 +406,14 @@ export default function IssueDetail() {
         }
     };
 
-    const adjustTextareaHeight = (textarea) => {
-        textarea.style.height = 'auto';
-        textarea.style.height = `${textarea.scrollHeight}px`;
-        textarea.style.minHeight = '96px'; // Default height (3 rows)
+    const adjustTextareaHeight = (textarea, reset = false) => {
+        if (reset) {
+            textarea.style.height = '96px'; // Default height (3 rows)
+        } else {
+            textarea.style.height = 'auto';
+            textarea.style.height = `${textarea.scrollHeight}px`;
+            textarea.style.minHeight = '96px'; // Default height (3 rows)
+        }
     };
 
     const handleSubmit = (e) => {

--- a/src/app/routes/issues.new.tsx
+++ b/src/app/routes/issues.new.tsx
@@ -184,12 +184,11 @@ export default function IssuesNew() {
 
     const handleTitleChange = (e) => {
         const newTitle = e.target.value;
+        setTitle(newTitle);
+        setTitleLength(newTitle.length);
+
         if (newTitle.length <= TITLE_MAX_LENGTH) {
-            setTitle(newTitle);
-            setTitleLength(newTitle.length);
             setShowTitleWarning(false);
-        } else {
-            setShowTitleWarning(true);
         }
     };
 
@@ -198,8 +197,6 @@ export default function IssuesNew() {
 
         if (title.length >= TITLE_MAX_LENGTH && isPrintableKey) {
             setShowTitleWarning(true);
-        } else {
-            setShowTitleWarning(false);
         }
     };
 

--- a/src/app/routes/issues.new.tsx
+++ b/src/app/routes/issues.new.tsx
@@ -129,6 +129,9 @@ export default function IssuesNew() {
     const titleRef = useRef(null);
     const descriptionRef = useRef(null);
 
+    const [titleLength, setTitleLength] = useState(0);
+    const [showTitleWarning, setShowTitleWarning] = useState(false);
+
     useEffect(() => {
         if (createIssueFetcher.data?.id != undefined) {
             localStorage.removeItem('create-issue-title');
@@ -179,6 +182,17 @@ export default function IssuesNew() {
         setIsFormValid(isTitleValid && isDescriptionValid);
     }, [title, description]);
 
+    const handleTitleChange = (e) => {
+        const newTitle = e.target.value;
+        if (newTitle.length <= TITLE_MAX_LENGTH) {
+            setTitle(newTitle);
+            setTitleLength(newTitle.length);
+            setShowTitleWarning(newTitle.length === TITLE_MAX_LENGTH);
+        } else {
+            setShowTitleWarning(true);
+        }
+    };
+
     const handleSubmit = (e) => {
         if (!isFormValid || createIssueFetcher.formData) {
             e.preventDefault();
@@ -211,10 +225,11 @@ export default function IssuesNew() {
                 </p>
             </div>
             <div className='flex justify-center mt-4 mx-4 md:mx-0'>
-                <createIssueFetcher.Form className='md:w-3/5' method='post' onSubmit={handleSubmit}>
-                    <Label htmlFor='title' className='text-lg'>
-                        Issue Title
-                    </Label>
+            <createIssueFetcher.Form className='md:w-3/5' method='post' onSubmit={handleSubmit}>
+                <Label htmlFor='title' className='text-lg'>
+                    Issue Title
+                </Label>
+                <div className="relative">
                     <Input
                         type='text'
                         name='title'
@@ -222,12 +237,23 @@ export default function IssuesNew() {
                         autoComplete='off'
                         minLength={TITLE_MIN_LENGTH}
                         maxLength={TITLE_MAX_LENGTH}
-                        className={classNames({ 'border-red-600': !!createIssueFetcher.data?.errors?.title })}
-                        onChange={(e) => setTitle(e.target.value)}
-                        defaultValue={title}
+                        className={classNames({
+                            'border-red-600': !!createIssueFetcher.data?.errors?.title || showTitleWarning
+                        })}
+                        onChange={handleTitleChange}
+                        value={title}
                         ref={titleRef}
                     />
-                    <FormErrorMessage className='mt-2'>{createIssueFetcher.data?.errors?.title}</FormErrorMessage>
+                    <span className={`absolute right-2 top-2 text-sm ${showTitleWarning ? 'text-red-600' : 'text-gray-500'}`}>
+                        {titleLength}/{TITLE_MAX_LENGTH}
+                    </span>
+                </div>
+                {showTitleWarning && (
+                    <p className="text-red-600 text-sm mt-1">
+                        Maximum title length reached.
+                    </p>
+                )}
+                <FormErrorMessage className='mt-2'>{createIssueFetcher.data?.errors?.title}</FormErrorMessage>
 
                     <div className='mt-4'>
                         <Label htmlFor='description' className='text-lg'>

--- a/src/app/routes/issues.new.tsx
+++ b/src/app/routes/issues.new.tsx
@@ -226,6 +226,18 @@ export default function IssuesNew() {
         }
     };
 
+    const adjustTextareaHeight = (textarea) => {
+        textarea.style.height = 'auto';
+        textarea.style.height = `${textarea.scrollHeight}px`;
+        textarea.style.minHeight = '192px'; // Default height (48 * 4)
+    };
+
+    useEffect(() => {
+        if (descriptionRef.current) {
+            adjustTextareaHeight(descriptionRef.current);
+        }
+    }, [description]);
+
     const handleSubmit = (e) => {
         if (!isFormValid || createIssueFetcher.formData) {
             e.preventDefault();
@@ -305,7 +317,10 @@ export default function IssuesNew() {
                                 autoComplete='off'
                                 minLength={DESCRIPTION_MIN_LENGTH}
                                 maxLength={DESCRIPTION_MAX_LENGTH}
-                                onChange={handleDescriptionChange}
+                                onChange={(e) => {
+                                    handleDescriptionChange(e);
+                                    adjustTextareaHeight(e.target);
+                                }}
                                 onKeyDown={handleDescriptionKeyPress}
                                 value={description}
                                 ref={descriptionRef}

--- a/src/app/routes/issues.new.tsx
+++ b/src/app/routes/issues.new.tsx
@@ -170,6 +170,10 @@ export default function IssuesNew() {
 
     useEffect(() => {
         localStorage.setItem('create-issue-description', description);
+
+        if (descriptionRef.current) {
+            adjustTextareaHeight(descriptionRef.current);
+        }
     }, [description]);
 
     useEffect(() => {
@@ -189,6 +193,12 @@ export default function IssuesNew() {
 
         setIsFormValid(isTitleValid && isDescriptionValid);
     }, [title, description]);
+
+    const adjustTextareaHeight = (textarea) => {
+        textarea.style.height = 'auto';
+        textarea.style.height = `${textarea.scrollHeight}px`;
+        textarea.style.minHeight = '192px'; // Default height (48 * 4)
+    };
 
     const handleTitleChange = (e) => {
         const newTitle = e.target.value;
@@ -225,18 +235,6 @@ export default function IssuesNew() {
             setShowDescriptionWarning(true);
         }
     };
-
-    const adjustTextareaHeight = (textarea) => {
-        textarea.style.height = 'auto';
-        textarea.style.height = `${textarea.scrollHeight}px`;
-        textarea.style.minHeight = '192px'; // Default height (48 * 4)
-    };
-
-    useEffect(() => {
-        if (descriptionRef.current) {
-            adjustTextareaHeight(descriptionRef.current);
-        }
-    }, [description]);
 
     const handleSubmit = (e) => {
         if (!isFormValid || createIssueFetcher.formData) {

--- a/src/app/routes/issues.new.tsx
+++ b/src/app/routes/issues.new.tsx
@@ -130,7 +130,9 @@ export default function IssuesNew() {
     const descriptionRef = useRef(null);
 
     const [titleLength, setTitleLength] = useState(0);
+    const [descriptionLength, setDescriptionLength] = useState(0);
     const [showTitleWarning, setShowTitleWarning] = useState(false);
+    const [showDescriptionWarning, setShowDescriptionWarning] = useState(false);
 
     useEffect(() => {
         if (createIssueFetcher.data?.id != undefined) {
@@ -147,7 +149,10 @@ export default function IssuesNew() {
             setTitle(savedTitle);
             setTitleLength(savedTitle.length);
         }
-        if (savedDescription) setDescription(savedDescription);
+        if (savedDescription) {
+            setDescription(savedDescription);
+            setDescriptionLength(savedDescription.length);
+        }
     }, []);
 
     useEffect(() => {
@@ -200,6 +205,24 @@ export default function IssuesNew() {
 
         if (title.length >= TITLE_MAX_LENGTH && isPrintableKey) {
             setShowTitleWarning(true);
+        }
+    };
+
+    const handleDescriptionChange = (e) => {
+        const newDescription = e.target.value;
+        setDescription(newDescription);
+        setDescriptionLength(newDescription.length);
+
+        if (newDescription.length <= DESCRIPTION_MAX_LENGTH) {
+            setShowDescriptionWarning(false);
+        }
+    };
+
+    const handleDescriptionKeyPress = (e) => {
+        const isPrintableKey = e.key.length === 1;
+
+        if (description.length >= DESCRIPTION_MAX_LENGTH && isPrintableKey) {
+            setShowDescriptionWarning(true);
         }
     };
 
@@ -270,21 +293,32 @@ export default function IssuesNew() {
                         <Label htmlFor='description' className='text-lg'>
                             Issue Description
                         </Label>
-                        <Textarea
-                            placeholder="Please describe your issue or suggestion here...
+                        <div className="relative">
+                            <Textarea
+                                placeholder="Please describe your issue or suggestion here...
 (Currently we don't support markdown for public issues, but we will in the future.)"
-                            name='description'
-                            className={classNames('h-48', {
-                                'border-red-600': !!createIssueFetcher.data?.errors?.description,
-                            })}
-                            required
-                            autoComplete='off'
-                            minLength={DESCRIPTION_MIN_LENGTH}
-                            maxLength={DESCRIPTION_MAX_LENGTH}
-                            onChange={(e) => setDescription(e.target.value)}
-                            defaultValue={description}
-                            ref={descriptionRef}
-                        />
+                                name='description'
+                                className={classNames('h-48', {
+                                    'border-red-600': !!createIssueFetcher.data?.errors?.description || showDescriptionWarning,
+                                })}
+                                required
+                                autoComplete='off'
+                                minLength={DESCRIPTION_MIN_LENGTH}
+                                maxLength={DESCRIPTION_MAX_LENGTH}
+                                onChange={handleDescriptionChange}
+                                onKeyDown={handleDescriptionKeyPress}
+                                value={description}
+                                ref={descriptionRef}
+                            />
+                            <span className={`absolute right-6 bottom-2 text-sm ${descriptionLength === DESCRIPTION_MAX_LENGTH ? 'text-red-600' : 'text-gray-500'}`}>
+                                {descriptionLength}/{DESCRIPTION_MAX_LENGTH}
+                            </span>
+                        </div>
+                        {showDescriptionWarning && (
+                            <p className="text-red-600 text-sm mt-1">
+                                Maximum description length reached.
+                            </p>
+                        )}
                         <FormErrorMessage className='mt-2'>
                             {createIssueFetcher.data?.errors?.description}
                         </FormErrorMessage>

--- a/src/app/routes/issues.new.tsx
+++ b/src/app/routes/issues.new.tsx
@@ -270,11 +270,15 @@ export default function IssuesNew() {
                 </p>
             </div>
             <div className='flex justify-center mt-4 mx-4 md:mx-0'>
-            <createIssueFetcher.Form className='md:w-3/5' method='post' onSubmit={handleSubmit}>
-                <Label htmlFor='title' className='text-lg'>
-                    Issue Title
-                </Label>
-                <div className="relative">
+                <createIssueFetcher.Form className='md:w-3/5' method='post' onSubmit={handleSubmit}>
+                    <div className="flex justify-between items-center">
+                        <Label htmlFor='title' className='text-lg'>
+                            Issue Title
+                        </Label>
+                        <span className={`text-sm ${titleLength === TITLE_MAX_LENGTH ? 'text-red-600' : 'text-gray-500'}`}>
+                            {titleLength}/{TITLE_MAX_LENGTH}
+                        </span>
+                    </div>
                     <Input
                         type='text'
                         name='title'
@@ -290,45 +294,41 @@ export default function IssuesNew() {
                         value={title}
                         ref={titleRef}
                     />
-                    <span className={`absolute right-2 top-2 text-sm ${titleLength === TITLE_MAX_LENGTH ? 'text-red-600' : 'text-gray-500'}`}>
-                        {titleLength}/{TITLE_MAX_LENGTH}
-                    </span>
-                </div>
-                {showTitleWarning && (
-                    <p className="text-red-600 text-sm mt-1">
-                        Maximum title length reached.
-                    </p>
-                )}
-                <FormErrorMessage className='mt-2'>{createIssueFetcher.data?.errors?.title}</FormErrorMessage>
+                    {showTitleWarning && (
+                        <p className="text-red-600 text-sm mt-1">
+                            Maximum title length reached.
+                        </p>
+                    )}
+                    <FormErrorMessage className='mt-2'>{createIssueFetcher.data?.errors?.title}</FormErrorMessage>
 
                     <div className='mt-4'>
-                        <Label htmlFor='description' className='text-lg'>
-                            Issue Description
-                        </Label>
-                        <div className="relative">
-                            <Textarea
-                                placeholder="Please describe your issue or suggestion here...
-(Currently we don't support markdown for public issues, but we will in the future.)"
-                                name='description'
-                                className={classNames('h-48', {
-                                    'border-red-600': !!createIssueFetcher.data?.errors?.description || showDescriptionWarning,
-                                })}
-                                required
-                                autoComplete='off'
-                                minLength={DESCRIPTION_MIN_LENGTH}
-                                maxLength={DESCRIPTION_MAX_LENGTH}
-                                onChange={(e) => {
-                                    handleDescriptionChange(e);
-                                    adjustTextareaHeight(e.target);
-                                }}
-                                onKeyDown={handleDescriptionKeyPress}
-                                value={description}
-                                ref={descriptionRef}
-                            />
-                            <span className={`absolute right-6 bottom-2 text-sm ${descriptionLength === DESCRIPTION_MAX_LENGTH ? 'text-red-600' : 'text-gray-500'}`}>
+                        <div className="flex justify-between items-center">
+                            <Label htmlFor='description' className='text-lg'>
+                                Issue Description
+                            </Label>
+                            <span className={`text-sm ${descriptionLength === DESCRIPTION_MAX_LENGTH ? 'text-red-600' : 'text-gray-500'}`}>
                                 {descriptionLength}/{DESCRIPTION_MAX_LENGTH}
                             </span>
                         </div>
+                        <Textarea
+                            placeholder="Please describe your issue or suggestion here...
+(Currently we don't support markdown for public issues, but we will in the future.)"
+                            name='description'
+                            className={classNames('h-48', {
+                                'border-red-600': !!createIssueFetcher.data?.errors?.description || showDescriptionWarning,
+                            })}
+                            required
+                            autoComplete='off'
+                            minLength={DESCRIPTION_MIN_LENGTH}
+                            maxLength={DESCRIPTION_MAX_LENGTH}
+                            onChange={(e) => {
+                                handleDescriptionChange(e);
+                                adjustTextareaHeight(e.target);
+                            }}
+                            onKeyDown={handleDescriptionKeyPress}
+                            value={description}
+                            ref={descriptionRef}
+                        />
                         {showDescriptionWarning && (
                             <p className="text-red-600 text-sm mt-1">
                                 Maximum description length reached.

--- a/src/app/routes/issues.new.tsx
+++ b/src/app/routes/issues.new.tsx
@@ -187,9 +187,19 @@ export default function IssuesNew() {
         if (newTitle.length <= TITLE_MAX_LENGTH) {
             setTitle(newTitle);
             setTitleLength(newTitle.length);
-            setShowTitleWarning(newTitle.length === TITLE_MAX_LENGTH);
+            setShowTitleWarning(false);
         } else {
             setShowTitleWarning(true);
+        }
+    };
+
+    const handleTitleKeyPress = (e) => {
+        const isPrintableKey = e.key.length === 1;
+
+        if (title.length >= TITLE_MAX_LENGTH && isPrintableKey) {
+            setShowTitleWarning(true);
+        } else {
+            setShowTitleWarning(false);
         }
     };
 
@@ -241,10 +251,11 @@ export default function IssuesNew() {
                             'border-red-600': !!createIssueFetcher.data?.errors?.title || showTitleWarning
                         })}
                         onChange={handleTitleChange}
+                        onKeyDown={handleTitleKeyPress}
                         value={title}
                         ref={titleRef}
                     />
-                    <span className={`absolute right-2 top-2 text-sm ${showTitleWarning ? 'text-red-600' : 'text-gray-500'}`}>
+                    <span className={`absolute right-2 top-2 text-sm ${titleLength === TITLE_MAX_LENGTH ? 'text-red-600' : 'text-gray-500'}`}>
                         {titleLength}/{TITLE_MAX_LENGTH}
                     </span>
                 </div>

--- a/src/app/routes/issues.new.tsx
+++ b/src/app/routes/issues.new.tsx
@@ -143,7 +143,10 @@ export default function IssuesNew() {
     useEffect(() => {
         const savedTitle = localStorage.getItem('create-issue-title');
         const savedDescription = localStorage.getItem('create-issue-description');
-        if (savedTitle) setTitle(savedTitle);
+        if (savedTitle) {
+            setTitle(savedTitle);
+            setTitleLength(savedTitle.length);
+        }
         if (savedDescription) setDescription(savedDescription);
     }, []);
 

--- a/src/app/routes/issues.new.tsx
+++ b/src/app/routes/issues.new.tsx
@@ -271,7 +271,7 @@ export default function IssuesNew() {
             </div>
             <div className='flex justify-center mt-4 mx-4 md:mx-0'>
                 <createIssueFetcher.Form className='md:w-3/5' method='post' onSubmit={handleSubmit}>
-                    <div className="flex justify-between items-center">
+                    <div className="flex justify-between items-center mb-1">
                         <Label htmlFor='title' className='text-lg'>
                             Issue Title
                         </Label>
@@ -302,7 +302,7 @@ export default function IssuesNew() {
                     <FormErrorMessage className='mt-2'>{createIssueFetcher.data?.errors?.title}</FormErrorMessage>
 
                     <div className='mt-4'>
-                        <div className="flex justify-between items-center">
+                        <div className="flex justify-between items-center mb-1">
                             <Label htmlFor='description' className='text-lg'>
                                 Issue Description
                             </Label>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/08af993c-7a17-409f-ab28-8a003616b866)

---

- Input fields also increase in height automatically now when visible area is completely filled.

![image](https://github.com/user-attachments/assets/c0dd4be9-7a8d-4d35-8e36-77d5e61de760)

---

- Standardize large text input fields to 4096 max length.

This makes the description, comment and contact input fields all the same.
Now that the max length is visible as a counter, it would be confusing why one they are different lengths.
4096 is chosen because Discord seems to limit the amount of characters to 4096.
