### PR TITLE
revert: add back issue ID to title on student server

### DIFF
--- a/src/app/routes/issues.new.tsx
+++ b/src/app/routes/issues.new.tsx
@@ -105,7 +105,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
                     await sendDiscordWebhookWithUrl(config.discord.studentServerIssueWebhookUrl, {
                         thread_name: `${data.title} - #${issue.id}`,
-                        content: `[A new Issue has been opened on the Student Council Website.](${config.baseUrl}/issues/${issue.id})`,
+                        content: `[A new issue has been opened on the Student Council Website.](${config.baseUrl}/issues/${issue.id})`,
                         wait: true,
                     })
                         .then(

--- a/src/app/routes/issues.new.tsx
+++ b/src/app/routes/issues.new.tsx
@@ -104,7 +104,7 @@ export async function action({ request }: ActionFunctionArgs) {
                         .catch(console.error);
 
                     await sendDiscordWebhookWithUrl(config.discord.studentServerIssueWebhookUrl, {
-                        thread_name: `${data.title}`,
+                        thread_name: `${data.title} - #${issue.id}`,
                         content: `[A new Issue has been opened on the Student Council Website.](${config.baseUrl}/issues/${issue.id})`,
                         wait: true,
                     })


### PR DESCRIPTION
I know we agreed that it's not necessary to have the ID in the title. 
But I just figured that we haven't considered that that opens up possibilities for people to troll. They can just create an issue with the same title as a hot issue but write some spam inside it.

I added it to the end of the title, same as for our council server, so it's just there to make the titles unique.

Ofc, if you guys still think it's not necessary then feel free to decline this PR, I just wanted to bring this up again so we also consider that case of potential trolling.

---

Also fix capitalization of ~~"Issue"~~ "issue".