### PR TITLE
feat: add comment direct link

### DIFF
--- a/src/app/routes/issues.$id.tsx
+++ b/src/app/routes/issues.$id.tsx
@@ -1,21 +1,15 @@
-import { LoaderFunctionArgs, MetaFunction, SerializeFrom } from '@remix-run/node';
-import NavBar from '~/components/NavBar';
-import { requireAdminSession, requireSessionData, SessionData } from '~/utils/session.server';
-import { useState, useEffect, useRef } from 'react';
-import { json } from '@remix-run/node';
-import { useLoaderData, Link, useFetcher, Form } from '@remix-run/react';
-import { Button } from '~/components/ui/button';
-import { db } from '~/utils/db.server';
-import { RateLimiterMemory } from 'rate-limiter-flexible';
+import { json, LoaderFunctionArgs, MetaFunction, SerializeFrom } from '@remix-run/node';
+import { Form, Link, useFetcher, useLoaderData } from '@remix-run/react';
+import classNames from 'classnames';
 import { ChevronLeft, Heart } from 'lucide-react';
+import { RateLimiterMemory } from 'rate-limiter-flexible';
+import { useEffect, useRef, useState } from 'react';
+import { z } from 'zod';
 import { FormErrorMessage } from '~/components/FormErrorMessage';
+import NavBar from '~/components/NavBar';
 import { Info } from '~/components/alert/Info';
 import { H1 } from '~/components/ui/H1';
 import { H2 } from '~/components/ui/H2';
-import { Checkbox } from '~/components/ui/checkbox';
-import { z } from 'zod';
-import { validateForm } from '~/utils/validation';
-import classNames from 'classnames';
 import {
     AlertDialog,
     AlertDialogAction,
@@ -27,9 +21,14 @@ import {
     AlertDialogTitle,
     AlertDialogTrigger,
 } from '~/components/ui/alert-dialog';
-import { sendDiscordWebhookWithUrl } from '~/utils/discord.server';
+import { Button } from '~/components/ui/button';
+import { Checkbox } from '~/components/ui/checkbox';
 import { config } from '~/utils/config.server';
 import { formatDate } from '~/utils/date';
+import { db } from '~/utils/db.server';
+import { sendDiscordWebhookWithUrl } from '~/utils/discord.server';
+import { requireAdminSession, requireSessionData, SessionData } from '~/utils/session.server';
+import { validateForm } from '~/utils/validation';
 
 const COMMENT_MIN_LENGTH = 3;
 const COMMENT_MAX_LENGTH = 5000;
@@ -221,7 +220,7 @@ export const action = async ({ request, params }: LoaderFunctionArgs) => {
                                         {
                                             color: embedColor,
                                             title: embedTitle,
-                                            description: `[A new comment has been posted to this issue](<${config.baseUrl}/issues/${issue?.id}>)`,
+                                            description: `[A new comment has been posted to this issue](<${config.baseUrl}/issues/${issue?.id}#${comment.id}>)`,
                                         },
                                     ],
                                     wait: true,
@@ -499,7 +498,7 @@ export default function IssueDetail() {
                         {issue.comments.length > 0 ? (
                             <ul>
                                 {issue.comments.map((comment) => (
-                                    <li key={comment.id}>
+                                    <li key={comment.id} id={comment.id.toString()}>
                                         <IssueComment comment={comment} issue={issue} />
                                     </li>
                                 ))}
@@ -571,13 +570,14 @@ function IssueComment({ comment, issue }: { comment: SerializeFrom<Comment>; iss
             })}
         >
             {comment.official && <p className='text-lg text-gray-400 font-bold'>Student Council Answer</p>}
-            <p
-                className={classNames('text-xs text-gray-600 pb-2', {
+            <Link
+                to={`#${comment.id}`}
+                className={classNames('text-xs text-gray-600 pb-2 hover:underline', {
                     'text-slate-600': comment.official,
                 })}
             >
                 {formatDate(new Date(comment.createdAt))}
-            </p>
+            </Link>
             <p
                 className={classNames('text-base text-gray-600 whitespace-pre-wrap break-words', {
                     'text-slate-800': comment.official,


### PR DESCRIPTION
Add comment ID to comment list element as ID.

Update Discord webhook to link directly to new comment using the hash.