### PR TITLE
fix: open footer links on same window

### DIFF
--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -14,14 +14,13 @@ export function Footer() {
             <div className='w-full px-6 py-2 flex flex-col sm:flex-row items-center justify-center sm:justify-between gap-x-7 gap-y-3'>
                 <div className='text-sm sm:text-center p-2'>
                     Made with <Heart className='text-rose-500 fill-current' /> by the{' '}
-                    <Link to='/about' target='_blank' className='hover:underline'>
+                    <Link to='/about' className='hover:underline'>
                         Student Council
                     </Link>
                 </div>
                 <div>
                     <Link
                         to='https://github.com/42-student-council/website/issues'
-                        target='_blank'
                         className='hover:underline flex gap-2 items-center p-2'
                     >
                         Found a bug? <GitHub className='size-5' />


### PR DESCRIPTION
Remove `_blank` from footer anchors to open links on the same window. Leave the choice up to the user.

Also fixes a non-friendly behavior when user clicks on "Student Council" while not authenticated.