### PR TITLE
fix: history overwrite on issue list

### DIFF
--- a/src/app/routes/issues._index.tsx
+++ b/src/app/routes/issues._index.tsx
@@ -85,7 +85,8 @@ export default function Issues() {
     const [filter, setFilter] = useState(initialIssueFilter);
 
     useEffect(() => {
-        if (filter === 'archived') {
+        if (filter === initialIssueFilter()) {
+        } else if (filter === 'archived') {
             setSearchParams({ filter: 'archived' });
         } else {
             setSearchParams({});


### PR DESCRIPTION
When going back to the issue list page, search params are always set again. This makes the browser believe there was a page change (creating a new history tree) and it deletes the forward history.