### PR TITLE
rec: add version numbers and automatic release notes

### DIFF
--- a/.github/workflows/prettier-format-write.yml
+++ b/.github/workflows/prettier-format-write.yml
@@ -42,7 +42,7 @@ jobs:
         run: npx prettier --config .prettierrc --write "**/*.{js,jsx,ts,tsx,html,css,scss}"
       - name: Commit changes
         run: |
-          git diff --exit-code || git commit -am "bot: apply Prettier formatting"
+          git diff --exit-code || git commit -am "bot: apply Prettier formatting [ignore]"
       - name: Push changes
         run: |
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release on Tag
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+  actions : write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env    :
+      VERSION:
+      PROCEED:
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref        : main
+          fetch-depth: 0
+
+      - name: Configure GitHub Actions bot
+        run : |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Get version number
+        run : echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
+
+      - name: Check tag version
+        run : |
+          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+          new_tag=${{ env.VERSION }}
+          if [[ $(printf '%s\n' "$latest_tag" "$new_tag" | sort -rV | head -n1) == "$new_tag" ]]; then
+            echo "PROCEED=true" >> "$GITHUB_ENV"
+          else
+            echo "PROCEED=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: ⏫ Update version number in script #TODO
+        if  : env.PROCEED == 'true'
+        run : |
+          sed -i "s/^current_version=.*/current_version=\"${{ env.VERSION }}\"/" 42free.sh
+          git add 42free.sh
+          git commit -m "bot: update version number to ${{ env.VERSION }} [ignore]" || exit 0
+          git push origin main
+          git tag -f ${{ env.VERSION }}
+          git push -f origin ${{ env.VERSION }}
+
+      - name: 📝 Generate changelog from commit messages
+        if  : ${{ env.PROCEED }} == 'true'
+        uses: ardalanamini/auto-changelog@v4
+        id  : changelog
+        with:
+          github-token            : ${{ github.token }}
+          commit-types            : |
+            feat: New Features
+            add: New Features
+            improve: Improvements
+            fix: Bug Fixes
+            build: Build System & Dependencies
+            perf: Performance Improvements
+            doc: Documentation
+            docs: Documentation
+            test: Tests
+            refactor: Refactors
+            chore: Chores
+            style: Code Style
+            ci: CI
+            cd: CD
+            revert: Reverts
+            bot: Bots
+          default-commit-type     : Other Changes
+          release-name            : ${{ env.VERSION }}
+          release-name-prefix     : ""
+          mention-authors         : true
+          mention-new-contributors: true
+          include-compare-link    : true
+          include-pr-links        : true
+          include-commit-links    : true
+          semver                  : true
+          use-github-autolink     : true
+
+      - name: 🚀 Release and upload asset
+        if  : env.PROCEED == 'true'
+        uses: softprops/action-gh-release@v2
+        env :
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          body        : ${{ steps.changelog.outputs.changelog }}
+
+      - name: 🛠️ Append dev to version number in script #TODO
+        if  : env.PROCEED == 'true'
+        run : |
+          new_version="${{ env.VERSION }}+dev"
+          sed -i "s/^current_version=.*/current_version=\"$new_version\"/" 42free.sh
+          git add 42free.sh
+          git commit -m "bot: update version number to $new_version [ignore]"
+          git push origin main

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -2,6 +2,8 @@ import { Link } from '@remix-run/react';
 import { Heart } from 'lucide-react';
 import { GitHub } from './icon/GitHub';
 
+const version = process.env.VERSION || '1.0.0'; // TODO
+
 export function Footer() {
     return (
         <footer
@@ -16,6 +18,15 @@ export function Footer() {
                     Made with <Heart className='text-rose-500 fill-current' /> by the{' '}
                     <Link to='/about' target='_blank' className='hover:underline'>
                         Student Council
+                    </Link>
+                </div>
+                <div className='text-sm text-gray-500 dark:text-gray-400'>
+                    <Link
+                        to='https://github.com/42-student-council/website/releases'
+                        target='_blank'
+                        className='hover:underline'
+                    >
+                        Version {version}
                     </Link>
                 </div>
                 <div>


### PR DESCRIPTION
Creating this PR to bump progress on https://github.com/42-student-council/website/issues/161

The release notes get generated from the commit messages in a nice Markdown format.

- [ ] Find a solution how to store the current version number.
- [ ] Change how to update the version numbers with the release Action.

Closes https://github.com/42-student-council/website/issues/161